### PR TITLE
feat: add tiles and playTurn logic

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,31 +1,21 @@
-import { StyleSheet, Text, View } from "react-native";
-import { useGame } from "../game";
+import { StyleSheet, View } from "react-native";
+import { Table } from "../components/table";
 
 const Home = () => {
-  const { board, activePlayer, changeTurn, placeSymbol } = useGame();
   return (
-    <View>
-      <View>
-        <View></View>
-        <View></View>
-        <View></View>
-      </View>
-
-      <View>
-        <View></View>
-        <View></View>
-        <View></View>
-      </View>
-
-      <View>
-        <View></View>
-        <View></View>
-        <View></View>
-      </View>
+    <View style={styles.container}>
+      <Table />
     </View>
   );
 };
 
 export default Home;
 
-const styles = StyleSheet.create({});
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    flexDirection: "column",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+});

--- a/components/table.tsx
+++ b/components/table.tsx
@@ -1,0 +1,42 @@
+import { StyleSheet, View } from "react-native";
+import { Tile } from "./tile";
+import { useGame } from "../game";
+
+export const Table = () => {
+  const { board, activePlayer, changeTurn, playTurn } = useGame();
+
+  return (
+    <View style={styles.table}>
+      {board.map((row, rowIndex) => (
+        <View style={styles.row} key={`row-${rowIndex}`}>
+          {row.map((tile, tileIndex) => (
+            <Tile
+              symbol={tile}
+              onPress={() => {
+                playTurn(rowIndex, tileIndex);
+              }}
+              key={`tile-${rowIndex}-${tileIndex}`}
+            ></Tile>
+          ))}
+        </View>
+      ))}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  table: {
+    flex: 1,
+    gap: 4,
+    flexDirection: "column",
+    width: "100%",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+
+  row: {
+    flex: 1,
+    gap: 4,
+    flexDirection: "row",
+  },
+});

--- a/components/tile.tsx
+++ b/components/tile.tsx
@@ -1,27 +1,30 @@
 import { Pressable, StyleSheet, Text, View } from "react-native";
+import { Symbol } from "../game";
 
 export const Tile = ({
-  playTurn,
-  contain = "",
+  onPress,
+  symbol = "",
 }: {
-  playTurn: () => void;
-  contain: "" | "O" | "X";
+  onPress: () => void;
+  symbol: Symbol;
 }) => {
   return (
-    <Pressable onPress={playTurn} style={styles.view}>
-      {contain}
+    <Pressable onPress={onPress} style={styles.view}>
+      <Text>{symbol}</Text>
     </Pressable>
   );
 };
 
 const styles = StyleSheet.create({
   view: {
-    width: 48,
-    height: 48,
-    backgroundColor: "#d6d6d6",
     flex: 1,
+    aspectRatio: 1 / 1,
+    backgroundColor: "#d6d6d6",
     justifyContent: "center",
     alignItems: "center",
     padding: 8,
+    borderColor: "#333",
+    borderRadius: 16,
+    borderWidth: 2,
   },
 });

--- a/game.ts
+++ b/game.ts
@@ -1,6 +1,12 @@
 import { useState } from "react";
 
-const emptyBoard = ["", "", "", "", "", "", "", "", ""];
+export type Symbol = "" | "O" | "X";
+
+const emptyBoard: Symbol[][] = [
+  ["", "", ""],
+  ["", "", ""],
+  ["", "", ""],
+];
 
 const winPatterns = [
   [0, 1, 2],
@@ -17,15 +23,23 @@ const winPatterns = [
 
 export const useGame = () => {
   const [board, setBoard] = useState(emptyBoard);
-  const [activePlayer, setActivePlayer] = useState("player 1");
+  const [activePlayer, setActivePlayer] = useState("1");
 
   const changeTurn = () => {
-    setActivePlayer(activePlayer === "player 1" ? "player 2" : "player 1");
+    setActivePlayer(activePlayer === "1" ? "2" : "1");
   };
 
-  const placeSymbol = (index: number) => {
-    if (board[index] !== "") return;
+  const playTurn = (row: number, column: number) => {
+    const tile = board[row][column];
+    if (tile !== "") return;
+    const symbol = activePlayer === "1" ? "X" : "O";
+    setBoard((board) => {
+      const boardClone = board.map((row) => [...row]); // Clones two dimensional array
+      boardClone[row][column] = symbol;
+      return boardClone;
+    });
+    changeTurn();
   };
 
-  return { board, activePlayer, changeTurn, placeSymbol };
+  return { board, activePlayer, changeTurn, playTurn };
 };


### PR DESCRIPTION
added working tiles
- playTurn logic
    - made board 3rd dimensional using arrays inside arrays in`emptyBoard`
    - made first param to take in the row eg. 0, 1, 2
    - made second param take in the tile eg. 0, 1, 2
    - since we update value inside an array inside an array we clone it, spread it and lastly return the `boardClone` with the updated board values